### PR TITLE
fix: remove mill.vcs.version from build

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,4 @@
 import $ivy.`com.goyeau::mill-scalafix::0.2.10`
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.3.0`
 import $ivy.`io.chris-kipp::mill-ci-release::0.1.1`
 
 import mill._


### PR DESCRIPTION
Instead use the one that mill-ci-release brings in
