### PR TITLE
feat: add in a sonatypeHost setting and Pom checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ this [here][sonatype-setup]. If you don't have a domain name you can use
 
 **NOTE**: Keep in mind that as of February 2021 newly created accounts are tied
 to https://s01.oss.sonatype.org/ whereas older accounts will be tied to
-https://oss.sonatype.org/. This matters when logging in, setting your resolvers,
-and setting your `sonatypeUri` and `sonatypeSnapshotUri`.
+https://oss.sonatype.org/. This matters when logging in. You'll also want to
+make sure you set `sonatypeHost` to `SonatypeHost.s01` in this scenario.
 
 ### Installing the Plugin
 
@@ -61,12 +61,14 @@ if you were extending `PublishModule`.
 you'll also want to ensure you add the following:
 
 ```diff
-+  override def sonatypeUri = "https://s01.oss.sonatype.org/service/local"
-+  override def sonatypeSnapshotUri =
-+    "https://s01.oss.sonatype.org/content/repositories/snapshots"
++ import io.kipp.mill.ci.release.SonatypeHost
+...
++  override def sonatypeHost = SonatypeHost.s01
 ```
 
-If you have an older account, then there is no need to change the default.
+This will then set the correct `sonatypeUri` and `sonatypeSnapshotUri` for you.
+If you have an older account, then there is no need to change the default or use
+`sonatypeHost` at all.
 
 ### GPG
 

--- a/build.sc
+++ b/build.sc
@@ -50,7 +50,6 @@ object plugin
   override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
     ivy"com.lihaoyi::mill-scalalib:${millVersion}"
   )
-
   override def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"de.tototec::de.tobiasroeser.mill.vcs.version_mill0.10::0.3.0"
   )

--- a/plugin/src/io/kipp/mill/ci/release/CiReleaseModule.scala
+++ b/plugin/src/io/kipp/mill/ci/release/CiReleaseModule.scala
@@ -22,6 +22,25 @@ trait CiReleaseModule extends PublishModule {
   override def publishVersion: T[String] = T {
     VcsVersion.vcsState().format(untaggedSuffix = "-SNAPSHOT")
   }
+
+  /** Helper available to users be able to more easily use the new s01 and
+    * future hosts for sonatype by just setting this.
+    */
+  def sonatypeHost: Option[SonatypeHost] = None
+
+  override def sonatypeUri: String = sonatypeHost match {
+    case Some(SonatypeHost.Legacy) => "https://oss.sonatype.org/service/local"
+    case Some(SonatypeHost.s01) => "https://s01.oss.sonatype.org/service/local"
+    case None                   => super.sonatypeUri
+  }
+
+  override def sonatypeSnapshotUri: String = sonatypeHost match {
+    case Some(SonatypeHost.Legacy) =>
+      "https://oss.sonatype.org/content/repositories/snapshots"
+    case Some(SonatypeHost.s01) =>
+      "https://s01.oss.sonatype.org/content/repositories/snapshots"
+    case None => super.sonatypeSnapshotUri
+  }
 }
 
 object ReleaseModule extends ExternalModule {

--- a/plugin/src/io/kipp/mill/ci/release/SonatypeHost.scala
+++ b/plugin/src/io/kipp/mill/ci/release/SonatypeHost.scala
@@ -1,0 +1,7 @@
+package io.kipp.mill.ci.release
+
+sealed trait SonatypeHost
+object SonatypeHost {
+  case object Legacy extends SonatypeHost
+  case object s01 extends SonatypeHost
+}


### PR DESCRIPTION
The intended use for this would be that all new people using the so1
hostname don't need to do this:

```
override def sonatypeUri = "https://s01.oss.sonatype.org/service/local"
override def sonatypeSnapshotUri =
  "https://s01.oss.sonatype.org/content/repositories/snapshots"
```

And they can instead just do:

```
override def sonatypeHost = SonatypeHost.s01
```

And it will set the correct `sonatypeUri` and `sonatypeSnapshotUri`. I
wanted to make s01 default, but this would break for people that have it
set up already using legacy host, and I see some that are using it with
that.

It looks like if you don't have a license set and at least one developer
listed in your `PomSettings` then when you try to publish Sonatype will
just silently fail. This adds in a check for both of those situations.