### PR TITLE
fix: make awaitTimer longer by default

### DIFF
--- a/plugin/src/io/kipp/mill/ci/release/CiReleaseModule.scala
+++ b/plugin/src/io/kipp/mill/ci/release/CiReleaseModule.scala
@@ -127,12 +127,10 @@ object ReleaseModule extends ExternalModule {
           "--armor",
           "--detach-sign"
         ),
-        // TODO look at some of the larger Mill projects, do they all just use the defaults,
-        // or should we make the defaults here a bit longer?
         readTimeout = 60000,
         connectTimeout = 5000,
         log,
-        awaitTimeout = 120 * 1000,
+        awaitTimeout = 600000,
         stagingRelease = true
       ).publishAll(
         release = true,


### PR DESCRIPTION
Just hit on this in bloop-config where this time wasn't long enough.
I notice that other repos in the com-liahoyi ecosystem for example are
using 600000 milis for this. So I'll just make thist eh default value.
