### PR TITLE
Make CiReleaseModule.setupGpg public

### DIFF
--- a/plugin/src/io/kipp/mill/ci/release/CiReleaseModule.scala
+++ b/plugin/src/io/kipp/mill/ci/release/CiReleaseModule.scala
@@ -161,7 +161,7 @@ object ReleaseModule extends ExternalModule {
 
   /** Ensures that your key is imported prio to signing and publishing.
     */
-  private def setupGpg() = T.task {
+  def setupGpg(): Task[Unit] = T.task {
     T.log.info("Attempting to setup gpg")
     val pgpSecret = envTask().pgpSecret.replaceAll("\\s", "")
     try {


### PR DESCRIPTION
I've been having issues setting up gpg with the way it's done currently here. This PR makes the `setupGpg` method public, so that users can override it to something else (to debug it say) or to a no-op.

I've been having such an error [here](https://github.com/coursier/mill-cs/actions/runs/4851840303/jobs/8646128769#step:6:147) in [this build](https://github.com/coursier/mill-cs/actions/runs/4851840303/jobs/8646128769), which gives
```text
Attempting to setup gpg
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
```
in spite of [an early manual command](https://github.com/coursier/mill-cs/blob/2c220e3786597d700967732683cc320a6cab5588/.github/scripts/gpg-setup.sh) with the same inputs, giving
```text
gpg: key 337EBD9967C97AC9: public key "" imported
gpg: key 337EBD9967C97AC9: secret key imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg:       secret keys read: 1
gpg:   secret keys imported: 1
```