### PR TITLE
Hard-code Mill version in import ivy

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,5 @@
 import $ivy.`com.goyeau::mill-scalafix::0.4.2`
-import $ivy.`io.chris-kipp::mill-ci-release::0.2.1`
+import $ivy.`io.chris-kipp::mill-ci-release_mill0.12:0.2.1`
 
 import mill._
 import mill.scalalib._


### PR DESCRIPTION
For me this makes publishing work. I have no idea, why it's not automatically picking the right version...